### PR TITLE
improve management textearea nohtml

### DIFF
--- a/javascripts/margot.js
+++ b/javascripts/margot.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
     parent.addClass($(this).attr("type"));
     if ($(this).hasClass('bazar-date')) parent.addClass('date');
     if ($(this).hasClass('summernote')) parent.addClass('summernote');
-    if ($(this).hasClass("wiki-textarea") || $(this).hasClass("nohtml")) {
+    if ($(this).hasClass("wiki-textarea")) {
       parent.addClass("wiki-textarea");
       parent.find(".control-label").prependTo(parent.find(".aceditor-toolbar"));
     }


### PR DESCRIPTION
En lien avec la PR en cours https://github.com/YesWiki/yeswiki/pull/546, petite modification pour considérer que 'nohtml' n'est pas un text-area mais un texte non formatté